### PR TITLE
Feature/remove map4 point type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,26 +13,28 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++fs")
 find_package(PkgConfig REQUIRED)
 pkg_check_modules(YAML_CPP REQUIRED yaml-cpp)
 
+find_package(PCL REQUIRED)
+
 find_package(catkin REQUIRED COMPONENTS
-  map4_point_type
 )
 
 catkin_package(
-  INCLUDE_DIRS include
-  CATKIN_DEPENDS map4_point_type
+  INCLUDE_DIRS include ${PCL_INCLUDE_DIRS}
+  DEPENDS PCL
   LIBRARIES ${PROJECT_NAME}
 )
 
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
+  ${PCL_INCLUDE_DIRS}
 )
 
 add_library(${PROJECT_NAME} SHARED src/pointcloud_divider_core.cpp)
-target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} -lstdc++fs)
+target_link_libraries(${PROJECT_NAME} PUBLIC ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} ${PCL_LIBRARIES} -lstdc++fs)
 
 add_executable(${PROJECT_NAME}_node
   src/pointcloud_divider_core.cpp
   src/pointcloud_divider_node.cpp
 )
-target_link_libraries(${PROJECT_NAME}_node PUBLIC ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} -lstdc++fs)
+target_link_libraries(${PROJECT_NAME}_node PUBLIC ${catkin_LIBRARIES} ${YAML_CPP_LIBRARIES} ${PCL_LIBRARIES} -lstdc++fs)

--- a/README.md
+++ b/README.md
@@ -1,15 +1,16 @@
 # pointcloud_divider
 
-(Updated 2023/03/01)
+(Updated 2023/03/27)
 
 Dividing large PCD files into 2D grids.
+
+**Currently, only pcl::PointXYZI is supported. Any PCD will be loaded as pcl::PointXYZI.**
 
 ## Installation
 
   ```
   mkdir -p hoge_ws/src
   cd hoge_ws/src
-  git clone git@github.com:MapIV/map4_point_type.git
   git clone git@github.com:MapIV/pointcloud_divider.git
   rosdep update
   rosdep install -y --from-paths src --ignore-src --rosdistro $ROS_DISTRO

--- a/include/pointcloud_divider/pointcloud_divider.hpp
+++ b/include/pointcloud_divider/pointcloud_divider.hpp
@@ -11,8 +11,6 @@
 #include <pcl/io/pcd_io.h>
 #include <pcl/filters/voxel_grid.h>
 
-#include <map4_point_type/map4_point_type.h>
-
 struct GridInfo
 {
   int x, y, gx, gy;

--- a/package.xml
+++ b/package.xml
@@ -7,8 +7,6 @@
   <license>BSD-3-Clauses</license>
   <buildtool_depend>catkin</buildtool_depend>
 
-  <depend>map4_point_type</depend>
-  
   <export>
   </export>
 </package>

--- a/src/pointcloud_divider_core.cpp
+++ b/src/pointcloud_divider_core.cpp
@@ -205,10 +205,8 @@ void PointCloudDivider<PointT>::paramInitialize()
     merged_ptr_.reset(new pcl::PointCloud<PointT>);
 }
 
-template class PointCloudDivider<pcl::PointXYZ>;
+// template class PointCloudDivider<pcl::PointXYZ>;
 template class PointCloudDivider<pcl::PointXYZI>;
-template class PointCloudDivider<pcl::PointXYZINormal>;
-template class PointCloudDivider<pcl::PointXYZRGB>;
-template class PointCloudDivider<pcl::PointNormal>;
-template class PointCloudDivider<PointXYZISC>;
-template class PointCloudDivider<PointXYZIRGBSC>;
+// template class PointCloudDivider<pcl::PointXYZINormal>;
+// template class PointCloudDivider<pcl::PointXYZRGB>;
+// template class PointCloudDivider<pcl::PointNormal>;

--- a/src/pointcloud_divider_node.cpp
+++ b/src/pointcloud_divider_node.cpp
@@ -1,9 +1,5 @@
 #include <pointcloud_divider/pointcloud_divider.hpp>
 
-#include <map4_point_type/type_detector.hpp>
-
-namespace mpe = map4_pcl_extensions;
-
 void printInvalidArguments()
 {
   std::cerr << "Error: Invalid Arugments" << std::endl;
@@ -37,42 +33,9 @@ int main(int argc, char* argv[])
     printInvalidArguments();
   }
 
-  mpe::PointType input_point_type = mpe::detectType(pcd_name[0]);
-  if (static_cast<int>(input_point_type) < 0)  // Double XYZ
-  {
-    std::cerr << "\033[31;1mError: DXYZ Point Type is not supported: " << static_cast<int>(input_point_type) << "\033[m"
-              << std::endl;
-    exit(4);
-  }
-  else
-  {
-    // Double to Float
-    if (input_point_type == mpe::PointType::PointXYZ)
-    {
-      PointCloudDivider<pcl::PointXYZ> divider;
-      divider.run(pcd_name, output_dir, prefix, config);
-    }
-    else if (input_point_type == mpe::PointType::PointXYZI)
-    {
-      PointCloudDivider<pcl::PointXYZI> divider;
-      divider.run(pcd_name, output_dir, prefix, config);
-    }
-    else if (input_point_type == mpe::PointType::PointXYZRGB)
-    {
-      PointCloudDivider<pcl::PointXYZRGB> divider;
-      divider.run(pcd_name, output_dir, prefix, config);
-    }
-    else if (input_point_type == mpe::PointType::PointXYZISC)
-    {
-      PointCloudDivider<PointXYZISC> divider;
-      divider.run(pcd_name, output_dir, prefix, config);
-    }
-    else if (input_point_type == mpe::PointType::PointXYZIRGBSC)
-    {
-      PointCloudDivider<PointXYZIRGBSC> divider;
-      divider.run(pcd_name, output_dir, prefix, config);
-    }
-  }
+  // Currently only PointXYZI is supported
+  PointCloudDivider<pcl::PointXYZI> divider;
+  divider.run(pcd_name, output_dir, prefix, config);
 
   return 0;
 }


### PR DESCRIPTION
# Description
* Removed [map4_point_type](https://github.com/MapIV/map4_point_type) because it can't move to colcon.
* Support only pcl::PointXYZI
