### PR TITLE
refactor: add error messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Dividing large PCD files into 2D grids.
 
 **Currently, only `pcl::PointXYZI` is supported. Any PCD will be loaded as `pcl::PointXYZI` .**
 
-This tool can be used with files that have data fields other than `XYZI` (e.g., `XYZRGB`) as well as files that only contain `XYZ`.
+This tool can be used with files that have data fields other than `XYZI` (e.g., `XYZRGB`) and files that only contain `XYZ`.
 
 * Data fields other than `XYZI` are ignored during loading.
 * When loading `XYZ`-only data, the `intensity` field is assigned 0.
@@ -39,12 +39,14 @@ $ make
   ```
 
   | Name       | Description                                  |
-  | -------    | -------------------------                    |
+  |------------|----------------------------------------------|
   | INPUT_DIR  | Directory that contains all PCD files        |
   | PCD_N      | Input PCD file name                          |
   | OUTPUT_DIR | Output directory name                        |
   | PREFIX     | Prefix of output PCD file name               |
   | CONFIG     | Config file ([default](config/default.yaml)) |
+
+ INPUT_DIR, PCD_N OUTPUT_DIR and CONFIG can be specified as both **relative paths** and **absolute paths**.
 
 ## Parameter
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,14 @@
 
 Dividing large PCD files into 2D grids.
 
-**Currently, only pcl::PointXYZI is supported. Any PCD will be loaded as pcl::PointXYZI.**
+## Supported Data Format
+
+**Currently, only `pcl::PointXYZI` is supported. Any PCD will be loaded as `pcl::PointXYZI` .**
+
+This tool can be used with files that have data fields other than `XYZI` (e.g., `XYZRGB`) as well as files that only contain `XYZ`.
+
+* Data fields other than `XYZI` are ignored during loading.
+* When loading `XYZ`-only data, the `intensity` field is assigned 0.
 
 ## Installation
 

--- a/include/pointcloud_divider/pointcloud_divider.hpp
+++ b/include/pointcloud_divider/pointcloud_divider.hpp
@@ -112,6 +112,7 @@ private:
   void saveGridPCD();
   void paramInitialize();
   void saveGridInfoToYAML(const std::string& yaml_file_path);
+  void checkOutputDirectoryValidity() const;
 };
 
 #endif

--- a/scripts/divider_core.sh
+++ b/scripts/divider_core.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 
+# Obtain the path to the application
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
 DIV_DIR=${SCRIPT_DIR%/*}
 PCD_DIV=$DIV_DIR"/build/pointcloud_divider"
@@ -39,24 +40,34 @@ else
 fi
 shift $(($OPTIND - 1))
 
+# Check the number of runtime arguments
+if [ "$#" -ge 5 ]; then
+  echo "Error: divider_core.sh requires more than 5 arguments."
+  usage
+  exit 1
+fi
+
 # Input arguments
 ARGC=$#
 ARGV=("$@")
 
-# Total number of input ROSBAGs
+# Total number of input PCD files
 N_PCD=$(($ARGC-3))
 
-# Prepare ROSBAG names
+# Prepare PCD file names
 PCD_FILES=""
 for (( i=0; i<N_PCD; i++ ))
 do
   PCD_FILES+="${ARGV[i]}"" "
 done
+
 # Remove trailing space if any
 PCD_FILES="$(echo -e "${PCD_FILES}" | sed -e 's/[[:space:]]*$//')"
 
+# Prepare other file pathes
 OUTPUT_DIR=${ARGV[$(($ARGC-3))]}"/"
 PREFIX=${ARGV[$(($ARGC-2))]}
 CONFIG_FILE=${ARGV[$(($ARGC-1))]}
 
+# Call the pointcloud_divider
 $PCD_DIV $N_PCD $PCD_FILES $OUTPUT_DIR $PREFIX $CONFIG_FILE

--- a/scripts/divider_core.sh
+++ b/scripts/divider_core.sh
@@ -41,8 +41,8 @@ fi
 shift $(($OPTIND - 1))
 
 # Check the number of runtime arguments
-if [ "$#" -ge 5 ]; then
-  echo "Error: divider_core.sh requires more than 5 arguments."
+if [ "$#" -lt 4 ]; then
+  echo "Error: divider_core.sh requires 4 or more arguments."
   usage
   exit 1
 fi

--- a/scripts/pointcloud_divider.sh
+++ b/scripts/pointcloud_divider.sh
@@ -1,10 +1,7 @@
 #!/bin/bash
 
+# Obtain the path to the primary script
 SCRIPT_DIR=$(cd $(dirname $0); pwd)
-DIV_DIR=${SCRIPT_DIR%/*}
-SRC_DIR=${DIV_DIR%/*}
-BASE_DIR=${SRC_DIR%/*}
-
 DIV_CORE=$SCRIPT_DIR"/divider_core.sh"
 
 # Show usage
@@ -17,7 +14,7 @@ Description:
   Dividing and downsampling PCD files into XY 2D rectangle grids.
 
 Options:
-  None
+  -h: Show this message.
 
 _EOT_
 }
@@ -42,11 +39,34 @@ else
 fi
 shift $(($OPTIND - 1))
 
+# Check the number of runtime arguments
+if [ "$#" -ne 4 ]; then
+  echo "Error: pointcloud_divider.sh requires 4 arguments."
+  usage
+  exit 1
+fi
+
+# Parse all mandatory arguments
 INPUT_DIR=$1
 OUTPUT_DIR=$2
 PREFIX=$3
 CONFIG_FILE=$4
 
+# Search all pcd files under the directory
+if [ ! -e "$INPUT_DIR" ]; then
+  echo "Error: $INPUT_DIR does not exists."
+  usage
+  exit 1
+fi
 PCD_FILES=$(find $INPUT_DIR -name "*.pcd" -printf "%p ")
 
+# Check the number of PCD files
+PCD_FILE_COUNT=$(echo $PCD_FILES| wc -w)
+if [ "$PCD_FILE_COUNT" -eq 0 ]; then
+  echo "Error: No valid PCD files are found."
+  usage
+  exit 1
+fi
+
+# Call the primary script
 $DIV_CORE $PCD_FILES $OUTPUT_DIR $PREFIX $CONFIG_FILE

--- a/src/pointcloud_divider.cpp
+++ b/src/pointcloud_divider.cpp
@@ -1,9 +1,9 @@
 #include <pcl/console/print.h>
 #include <pointcloud_divider/pointcloud_divider.hpp>
 
-void printInvalidArguments()
+void printErrorAndExit(const std::string& message)
 {
-  std::cerr << "Error: Invalid Arugments" << std::endl;
+  std::cerr << "Error: "<< message << std::endl;
   exit(1);
 }
 
@@ -13,30 +13,26 @@ int main(int argc, char* argv[])
   // `Failed to find match for field 'intensity'.`
   pcl::console::setVerbosityLevel(pcl::console::VERBOSITY_LEVEL::L_ERROR);
 
-  int n_pcd;
+  if (argc <= 1)
+  {
+    printErrorAndExit("There should be at least 6 runtime arguments.");
+  }
+
+  const int n_pcd = std::stoi(argv[1]);
+
+  if (argc != 5 + n_pcd)
+  {
+    printErrorAndExit("There should be " + std::to_string(5 + n_pcd) + " runtime arguments. input: " + std::to_string(argc) );
+  }
+
   std::vector<std::string> pcd_name;
-  std::string output_dir, prefix, config;
-
-  if (argc <= 0)
+  for (int pcd_id = 0; pcd_id < n_pcd; pcd_id++)
   {
-    printInvalidArguments();
+    pcd_name.push_back(argv[2 + pcd_id]);
   }
-
-  n_pcd = std::stoi(argv[1]);
-  if (argc == 5 + n_pcd)
-  {
-    for (int pcd_id = 0; pcd_id < n_pcd; pcd_id++)
-    {
-      pcd_name.push_back(argv[2 + pcd_id]);
-    }
-    output_dir = argv[n_pcd + 2];
-    prefix = argv[n_pcd + 3];
-    config = argv[n_pcd + 4];
-  }
-  else
-  {
-    printInvalidArguments();
-  }
+  const std::string output_dir = argv[n_pcd + 2];
+  const std::string prefix = argv[n_pcd + 3];
+  const std::string config = argv[n_pcd + 4];
 
   // Currently, any PCD will be loaded as pcl::PointXYZI.
   PointCloudDivider<pcl::PointXYZI> divider;

--- a/src/pointcloud_divider.cpp
+++ b/src/pointcloud_divider.cpp
@@ -3,7 +3,7 @@
 
 void printErrorAndExit(const std::string& message)
 {
-  std::cerr << "Error: "<< message << std::endl;
+  std::cerr << "Error: " << message << std::endl;
   exit(1);
 }
 
@@ -22,7 +22,8 @@ int main(int argc, char* argv[])
 
   if (argc != 5 + n_pcd)
   {
-    printErrorAndExit("There should be " + std::to_string(5 + n_pcd) + " runtime arguments. input: " + std::to_string(argc) );
+    printErrorAndExit("There should be " + std::to_string(5 + n_pcd) +
+                      " runtime arguments. input: " + std::to_string(argc));
   }
 
   std::vector<std::string> pcd_name;

--- a/src/pointcloud_divider.cpp
+++ b/src/pointcloud_divider.cpp
@@ -39,5 +39,6 @@ int main(int argc, char* argv[])
   PointCloudDivider<pcl::PointXYZI> divider;
   divider.run(pcd_name, output_dir, prefix, config);
 
+  std::cout << "pointcloud_divider has finished successfully" << std::endl;
   return 0;
 }

--- a/src/pointcloud_divider.cpp
+++ b/src/pointcloud_divider.cpp
@@ -1,3 +1,4 @@
+#include <pcl/console/print.h>
 #include <pointcloud_divider/pointcloud_divider.hpp>
 
 void printInvalidArguments()
@@ -8,6 +9,10 @@ void printInvalidArguments()
 
 int main(int argc, char* argv[])
 {
+  // Change the default PCL's log level to suppress the following message:
+  // `Failed to find match for field 'intensity'.`
+  pcl::console::setVerbosityLevel(pcl::console::VERBOSITY_LEVEL::L_ERROR);
+
   int n_pcd;
   std::vector<std::string> pcd_name;
   std::string output_dir, prefix, config;
@@ -33,7 +38,7 @@ int main(int argc, char* argv[])
     printInvalidArguments();
   }
 
-  // Currently only PointXYZI is supported
+  // Currently, any PCD will be loaded as pcl::PointXYZI.
   PointCloudDivider<pcl::PointXYZI> divider;
   divider.run(pcd_name, output_dir, prefix, config);
 

--- a/src/pointcloud_divider_core.cpp
+++ b/src/pointcloud_divider_core.cpp
@@ -19,6 +19,7 @@ void PointCloudDivider<PointT>::run(const typename pcl::PointCloud<PointT>::Ptr&
   grid_set_.clear();
 
   paramInitialize();
+  checkOutputDirectoryValidity();
   dividePointCloud(cloud_ptr);
   saveGridPCD();
   saveMergedPCD();
@@ -34,6 +35,7 @@ void PointCloudDivider<PointT>::run(std::vector<std::string> pcd_names, std::str
 
   grid_set_.clear();
   paramInitialize();
+  checkOutputDirectoryValidity();
 
   for (const std::string& pcd_name : pcd_names)
   {
@@ -49,30 +51,45 @@ void PointCloudDivider<PointT>::run(std::vector<std::string> pcd_names, std::str
 }
 
 template <class PointT>
+void PointCloudDivider<PointT>::checkOutputDirectoryValidity() const
+{
+  if (!std::filesystem::exists(output_dir_))
+  {
+    std::cerr << "Error: " << output_dir_
+              << " does not exist. Please make the directory before execute this application." << std::endl;
+    exit(1);
+  }
+}
+
+template <class PointT>
 typename pcl::PointCloud<PointT>::Ptr PointCloudDivider<PointT>::loadPCD(const std::string& pcd_name)
 {
   {
     // Read only the header of the PCD file and warn if the data fields are different from XYZI.
     pcl::PCDReader reader;
     pcl::PCLPointCloud2 cloud;
-    if (reader.readHeader(pcd_name, cloud) != 0) {
+    if (reader.readHeader(pcd_name, cloud) != 0)
+    {
       std::cerr << "Error: Cannot load PCD: " << pcd_name << std::endl;
       exit(1);
     }
 
     std::set<std::string> field_set;
-    for(const auto& field: cloud.fields){
+    for (const auto& field : cloud.fields)
+    {
       field_set.insert(field.name);
     }
 
-    if (field_set.count("intensity") == 0) {
+    if (field_set.count("intensity") == 0)
+    {
       std::cerr << "Warning: " << pcd_name << " does not contains `intensity` field,  substituted with 0." << std::endl;
     }
   }
 
   typename pcl::PointCloud<PointT>::Ptr cloud_ptr(new pcl::PointCloud<PointT>);
 
-  if (pcl::io::loadPCDFile(pcd_name, *cloud_ptr) == -1) {
+  if (pcl::io::loadPCDFile(pcd_name, *cloud_ptr) == -1)
+  {
     std::cerr << "Error: Cannot load PCD: " << pcd_name << std::endl;
     exit(1);
   }

--- a/src/pointcloud_divider_core.cpp
+++ b/src/pointcloud_divider_core.cpp
@@ -51,10 +51,28 @@ void PointCloudDivider<PointT>::run(std::vector<std::string> pcd_names, std::str
 template <class PointT>
 typename pcl::PointCloud<PointT>::Ptr PointCloudDivider<PointT>::loadPCD(const std::string& pcd_name)
 {
+  {
+    // Read only the header of the PCD file and warn if the data fields are different from XYZI.
+    pcl::PCDReader reader;
+    pcl::PCLPointCloud2 cloud;
+    if (reader.readHeader(pcd_name, cloud) != 0) {
+      std::cerr << "Error: Cannot load PCD: " << pcd_name << std::endl;
+      exit(1);
+    }
+
+    std::set<std::string> field_set;
+    for(const auto& field: cloud.fields){
+      field_set.insert(field.name);
+    }
+
+    if (field_set.count("intensity") == 0) {
+      std::cerr << "Warning: " << pcd_name << " does not contains `intensity` field,  substituted with 0." << std::endl;
+    }
+  }
+
   typename pcl::PointCloud<PointT>::Ptr cloud_ptr(new pcl::PointCloud<PointT>);
 
-  if (pcl::io::loadPCDFile(pcd_name, *cloud_ptr) == -1)
-  {
+  if (pcl::io::loadPCDFile(pcd_name, *cloud_ptr) == -1) {
     std::cerr << "Error: Cannot load PCD: " << pcd_name << std::endl;
     exit(1);
   }


### PR DESCRIPTION
Please review & merge https://github.com/MapIV/pointcloud_divider/pull/5 first. 

* Added some comments and error message for users.
* This PR does not change the divider output.

## Hot to test
1. `./scripts/pointcloud_divider.sh input.pcd ./ prefix config/default.yaml`
-> *pointcloud_divider has finished successfully*

1. `./scripts/pointcloud_divider.sh input.pcd dir_does_not_exist prefix config/default.yaml`
-> *Error: dir_does_not_exist/ does not exist. Please make the directory before execute this application.*

1. `./scripts/pointcloud_divider.sh input.pcd ./ prefix config/default.yaml redundant_arg`
-> *Error: pointcloud_divider.sh requires 4 arguments.*

1. `./scripts/pointcloud_divider.sh input.pcd ./ prefix`
-> *Error: pointcloud_divider.sh requires 4 arguments.*

1. `./scripts/pointcloud_divider.sh does_not_exist.pcd ./ prefix config/default.yaml`
-> *Error: does_not_exist.pcd does not exists.*

1. `mv input.pcd input/input.pcd; ./scripts/pointcloud_divider.sh input/ ./ prefix config/default.yaml`
-> *pointcloud_divider has finished successfully*
